### PR TITLE
Migrating to recent lws version

### DIFF
--- a/WebSocketServer.h
+++ b/WebSocketServer.h
@@ -75,10 +75,10 @@ protected:
     // Nothing, yet.
 
 private:
-    int                          _port;    
-    string                       _keyPath;
-    string                       _certPath;
-    struct libwebsocket_context *_context;
+    int                  _port;    
+    string               _keyPath;
+    string               _certPath;
+    struct lws_context  *_context;
     
     void _removeConnection( int socketID );
 };


### PR DESCRIPTION
Hello, libwebsocket team has changed their api, which has rendered your code unusable. It is mostly only renaming of the methods used, from libwebsocket_* to lws_*, but also some minor arguments changes. These changes concern **libwebsocket version 1.6** (if I am not mistaken).
I've also added keepalive settings to the context when creating server. From [documentation](https://libwebsockets.org/libwebsockets-api-doc.html)

> - ka_time
>   0 for no keepalive, otherwise apply this keepalive timeout to all libwebsocket sockets, client or server 
> - ka_probes
>   if ka_time was nonzero, after the timeout expires how many times to try to get a response from the peer before giving up and killing the connection 
> - ka_interval
>   if ka_time was nonzero, how long to wait before each ka_probes attemp
