### PR TITLE
Fix memory overflow on msg receive

### DIFF
--- a/WebSocketServer.cpp
+++ b/WebSocketServer.cpp
@@ -61,7 +61,7 @@ static int callback_main(   struct lws *wsi,
             break;
 
         case LWS_CALLBACK_RECEIVE:
-            self->onMessage( lws_get_socket_fd( wsi ), string( (const char *)in ) );
+            self->onMessage( lws_get_socket_fd( wsi ), string( (const char *)in, len ) );
             break;
 
         case LWS_CALLBACK_CLOSED:


### PR DESCRIPTION
By not providing `len` (the msg length) to the string constructor, it will overflow the expected size in search of a \0 char, adding garbage to the string and potentially creating a segfault.